### PR TITLE
ci: drop Python 3.11, add Python 3.14 to linters matrix

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Drops Python 3.11 from the linters workflow test matrix
- Adds Python 3.14

## Test plan
- [x] CI run passes on 3.12, 3.13, 3.14